### PR TITLE
Add unimol-style pretrain dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ export UNIMOL_WEIGHT_DIR=/path/to/your/weights/dir/
 - 2024-06-25: unimol_tools has been publish to pypi! Huggingface has been used to manage the pretrain models.
 - 2024-06-20: unimol_tools v0.1.0 released, we remove the dependency of Uni-Core. And we will publish to pypi soon.
 - 2024-03-20: unimol_tools documents is available at https://unimol-tools.readthedocs.io/en/latest/
+- 2025-07-17: Pretrain dataset generation now supports the original Uni-Mol multi-conformer style.
+- 2025-07-20: Pretrain preprocessing can now read CSV or SMI files; the SMILES column should be named `smi`.
+- 2025-07-21: Preprocessing accepts molecule dictionaries with `atoms`/`coordinates` and the trainer saves `checkpoint_last.ckpt` and `checkpoint_best.ckpt` during training.
+- 2025-07-22: Preprocessing now supports SDF molecule files.
+- 2025-07-23: Pretraining automatically resumes from `checkpoint_last.ckpt` and selects the best model using validation loss.
+- 2025-07-24: Validation and checkpoint saving run every `save_every_n_epoch` epochs instead of each epoch.
 
 ## Examples
 ### Molecule property prediction

--- a/tests/test_preprocess_sdf.py
+++ b/tests/test_preprocess_sdf.py
@@ -1,0 +1,22 @@
+from rdkit import Chem
+from rdkit.Chem import AllChem
+
+from unimol_tools.pretrain.preprocess import preprocess_dataset
+from unimol_tools.pretrain.dataset import LMDBDataset
+
+
+def test_preprocess_sdf(tmp_path):
+    mol = Chem.MolFromSmiles('CCO')
+    mol = Chem.AddHs(mol)
+    AllChem.EmbedMolecule(mol, randomSeed=1)
+    writer = Chem.SDWriter(str(tmp_path / 'mols.sdf'))
+    writer.write(mol)
+    writer.close()
+
+    lmdb_path = tmp_path / 'mols.lmdb'
+    preprocess_dataset(str(tmp_path / 'mols.sdf'), str(lmdb_path), data_type='sdf')
+
+    dataset = LMDBDataset(str(lmdb_path))
+    item = dataset[0]
+    assert len(item['atoms']) == len(item['coordinates'])
+    assert item['smi'] == Chem.MolToSmiles(mol)

--- a/unimol_tools/pretrain/__init__.py
+++ b/unimol_tools/pretrain/__init__.py
@@ -1,6 +1,6 @@
 from .dataset import LMDBDataset, UniMolDataset
 from .loss import UniMolloss
-from .preprocess import build_dictionary
+from .preprocess import build_dictionary, preprocess_dataset
 from .pretrain_config import PretrainConfig
 from .trainer import UniMolPretrainTrainer
 from .unimol import UniMolModel

--- a/unimol_tools/pretrain/dataset.py
+++ b/unimol_tools/pretrain/dataset.py
@@ -39,7 +39,7 @@ class LMDBDataset(Dataset):
             'idx': item.get('idx'),
             'atoms': atoms,
             'coordinates': coordinates,
-            'smiles': item.get('smiles'),
+            'smi': item.get('smi'),
         }
         return result
 
@@ -47,7 +47,7 @@ class UniMolDataset(Dataset):
     """
     Loads LMDBDataset for UniMol models.
     """
-    def __init__(self, lmdb_dataset, dictionary, remove_hs=False, max_atoms=256, seed=1, **params):
+    def __init__(self, lmdb_dataset, dictionary, remove_hs=False, max_atoms=256, seed=1, sample_conformer=False, **params):
         self.dataset = lmdb_dataset
         self.length = len(self.dataset)
         self.dictionary = dictionary
@@ -55,6 +55,7 @@ class UniMolDataset(Dataset):
         self.max_atoms = max_atoms
         self.seed = seed
         self.params = params
+        self.sample_conformer = sample_conformer
         self.mask_id = dictionary.add_symbol("[MASK]", is_special=True)
         self.set_epoch(0)  # Initialize epoch to 0
 
@@ -78,9 +79,17 @@ class UniMolDataset(Dataset):
         item = self.dataset[idx]
         atoms = item['atoms']
         coordinates = item['coordinates']
-        
+
         if atoms is None or coordinates is None:
             raise ValueError(f"Invalid data at index {idx}: atoms or coordinates are None.")
+
+        if isinstance(coordinates, list):
+            if self.sample_conformer:
+                np.random.seed(self.seed + epoch + idx)
+                sel = np.random.randint(len(coordinates))
+                coordinates = coordinates[sel]
+            else:
+                coordinates = coordinates[0]
         
         net_input, target = coords2unimol(
             atoms=atoms, 

--- a/unimol_tools/pretrain/preprocess.py
+++ b/unimol_tools/pretrain/preprocess.py
@@ -1,5 +1,6 @@
 import os
 import pickle
+import logging
 
 import lmdb
 import numpy as np
@@ -8,6 +9,10 @@ from tqdm import tqdm
 
 from unimol_tools.data import Dictionary
 from unimol_tools.data.conformer import inner_smi2coords
+from rdkit import Chem
+from rdkit.Chem import AllChem
+
+logger = logging.getLogger(__name__)
 
 
 def build_dictionary(lmdb_path, save_path=None):
@@ -44,9 +49,11 @@ def build_dictionary(lmdb_path, save_path=None):
         np.savetxt(f, dictionary, fmt='%s')
     return Dictionary.from_list(dictionary)
 
-def write_to_lmdb(lmdb_path, smiles_list):
+def write_to_lmdb(lmdb_path, smi_list, num_conf=1, unimol_style=False, remove_hs=False):
+    logger.info(f"Writing {len(smi_list)} SMILES to {lmdb_path}")
 
-    env = lmdb.open(lmdb_path,
+    env = lmdb.open(
+        lmdb_path,
         subdir=False,
         readonly=False,
         lock=False,
@@ -56,38 +63,100 @@ def write_to_lmdb(lmdb_path, smiles_list):
         map_size=int(100e9),  # 100GB
     )
     txn_write = env.begin(write=True)
-    for i in tqdm(range(len(smiles_list)), total=len(smiles_list)):
-        inner_output = process_smiles(smiles_list[i], i)
+    for i in tqdm(range(len(smi_list)), total=len(smi_list)):
+        inner_output = process_smi(
+            smi_list[i],
+            i,
+            remove_hs=remove_hs,
+            num_conf=num_conf,
+            unimol_style=unimol_style,
+        )
         if inner_output is not None:
             idx, data = inner_output
             txn_write.put(str(idx).encode(), data)
-        if (i+1) % 1000 == 0:
+        if (i + 1) % 1000 == 0:
             txn_write.commit()
             txn_write = env.begin(write=True)
-    print(f"process {i+1} lines")
+    logger.info(f"Processed {i+1} molecules")
     txn_write.commit()
     env.close()
-    print(f"已保存到LMDB: {lmdb_path}")
+    logger.info(f"Saved to LMDB: {lmdb_path}")
     return lmdb_path
 
-def process_smiles(smiles, idx, remove_hs=False, **params):
-    """
-    Process a single SMILES string and return index and serialized data.
-    """
-    atoms, coordinates, mol = inner_smi2coords(
-                smiles, seed=42, mode='fast', remove_hs=remove_hs
+
+def write_dicts_to_lmdb(lmdb_path, mol_list):
+    """Write a list of pre-generated molecules to LMDB."""
+    logger.info(f"Writing {len(mol_list)} molecule dicts to {lmdb_path}")
+
+    env = lmdb.open(
+        lmdb_path,
+        subdir=False,
+        readonly=False,
+        lock=False,
+        readahead=False,
+        meminit=False,
+        max_readers=1,
+        map_size=int(100e9),
+    )
+    txn_write = env.begin(write=True)
+    for i, item in enumerate(tqdm(mol_list, total=len(mol_list))):
+        data = {
+            "idx": i,
+            "atoms": item["atoms"],
+            "coordinates": item["coordinates"],
+        }
+        if "smi" in item:
+            data["smi"] = item["smi"]
+        txn_write.put(str(i).encode(), pickle.dumps(data))
+        if (i + 1) % 1000 == 0:
+            txn_write.commit()
+            txn_write = env.begin(write=True)
+    logger.info(f"Processed {i+1} molecules")
+    txn_write.commit()
+    env.close()
+    logger.info(f"Saved to LMDB: {lmdb_path}")
+    return lmdb_path
+
+def smi2_2dcoords(smiles):
+    mol = Chem.MolFromSmiles(smiles)
+    mol = AllChem.AddHs(mol)
+    AllChem.Compute2DCoords(mol)
+    coordinates = mol.GetConformer().GetPositions().astype(np.float32)
+    assert len(mol.GetAtoms()) == len(coordinates)
+    return coordinates
+
+
+def process_smi(smi, idx, remove_hs=False, num_conf=1, unimol_style=False, **params):
+    """Process a single SMILES string and return index and serialized data."""
+    if unimol_style:
+        conformers = []
+        for i in range(num_conf):
+            atoms, coordinates, _ = inner_smi2coords(
+                smi, seed=42 + i, mode="fast", remove_hs=remove_hs
             )
-    # atomic_numbers = [atom.GetAtomicNum() for atom in mol.GetAtoms()]
-    data = {
-        'idx': idx,
-        'atoms': atoms,
-        'coordinates': coordinates,
-        'smiles': smiles,
-    }
+            conformers.append(coordinates)
+        conformers.append(smi2_2dcoords(smi))
+        data = {
+            "idx": idx,
+            "atoms": atoms,
+            "coordinates": conformers,
+            "smi": smi,
+        }
+    else:
+        atoms, coordinates, _ = inner_smi2coords(
+            smi, seed=42, mode="fast", remove_hs=remove_hs
+        )
+        data = {
+            "idx": idx,
+            "atoms": atoms,
+            "coordinates": coordinates,
+            "smi": smi,
+        }
 
     return idx, pickle.dumps(data)
 
-def process_csv(csv_path, smiles_col='SMILES'):
+
+def process_csv(csv_path, smiles_col='smi'):
     """
     Read a CSV file and return a list of SMILES strings.
     """
@@ -95,4 +164,85 @@ def process_csv(csv_path, smiles_col='SMILES'):
     if smiles_col not in df.columns:
         raise ValueError(f"Column '{smiles_col}' not found in CSV file.")
     return df[smiles_col].tolist()
+
+
+def process_smi_file(file_path):
+    """Read a file containing one SMILES per line."""
+    with open(file_path, 'r') as f:
+        return [line.strip() for line in f if line.strip()]
+
+
+def process_sdf_file(file_path, remove_hs=False):
+    """Read an SDF file and return a list of molecule dicts."""
+    supplier = Chem.SDMolSupplier(file_path, removeHs=False)
+    mols = []
+    for mol in supplier:
+        if mol is None:
+            continue
+        if remove_hs:
+            mol = Chem.RemoveHs(mol)
+        atoms = [atom.GetSymbol() for atom in mol.GetAtoms()]
+        conf = mol.GetConformer()
+        coords = conf.GetPositions().astype(np.float32)
+        smi = Chem.MolToSmiles(mol)
+        mols.append({"atoms": atoms, "coordinates": coords, "smi": smi})
+    return mols
+
+def preprocess_dataset(data, lmdb_path, data_type='smi', smiles_col='smi',
+                       num_conf=1, unimol_style=False, remove_hs=False):
+    """Preprocess various dataset formats into an LMDB file.
+
+    Args:
+        data: Input data; can be path or list depending on ``data_type``.
+        lmdb_path: Path to the output LMDB file.
+        data_type: Format of the input data. Supported values are
+            ``'smi'``/``'txt'`` for a file with one SMILES per line,
+            ``'csv'`` for CSV files, ``'sdf'`` for SDF molecule files,
+            ``'list'`` for a Python list of SMILES strings and ``'dict'``
+            for a list of molecule dicts containing ``atoms`` and
+            ``coordinates``.
+        smiles_col: Column name used when ``data_type='csv'``.
+    """
+    logger.info(f"Preprocessing data of type '{data_type}' to {lmdb_path}")
+    if data_type in ['smi', 'txt']:
+        smi_list = process_smi_file(data)
+        logger.info(f"Loaded {len(smi_list)} SMILES from file")
+        return write_to_lmdb(
+            lmdb_path,
+            smi_list,
+            num_conf=num_conf,
+            unimol_style=unimol_style,
+            remove_hs=remove_hs,
+        )
+    elif data_type == 'csv':
+        smi_list = process_csv(data, smiles_col=smiles_col)
+        logger.info(f"Loaded {len(smi_list)} SMILES from CSV")
+        return write_to_lmdb(
+            lmdb_path,
+            smi_list,
+            num_conf=num_conf,
+            unimol_style=unimol_style,
+            remove_hs=remove_hs,
+        )
+    elif data_type == 'sdf':
+        mols = process_sdf_file(data, remove_hs=remove_hs)
+        logger.info(f"Loaded {len(mols)} molecules from SDF")
+        return write_dicts_to_lmdb(lmdb_path, mols)
+    elif data_type == 'list':
+        smi_list = list(data)
+        logger.info(f"Loaded {len(smi_list)} SMILES from list")
+        return write_to_lmdb(
+            lmdb_path,
+            smi_list,
+            num_conf=num_conf,
+            unimol_style=unimol_style,
+            remove_hs=remove_hs,
+        )
+    elif data_type == 'dict':
+        if not isinstance(data, (list, tuple)):
+            raise ValueError("'dict' data_type expects a list of dictionaries")
+        return write_dicts_to_lmdb(lmdb_path, data)
+    else:
+        raise ValueError(f"Unsupported data_type: {data_type}")
+
 

--- a/unimol_tools/pretrain/pretrain_config.py
+++ b/unimol_tools/pretrain/pretrain_config.py
@@ -2,12 +2,15 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 from hydra.core.config_store import ConfigStore
-from omegaconf import MISSING
 
 
 @dataclass
 class DatasetConfig:
-    train_lmdb: str = MISSING
+    train_lmdb: Optional[str] = None
+    train_path: Optional[str] = None
+    valid_path: Optional[str] = None
+    data_type: str = "lmdb"
+    smiles_column: str = "smi"
     valid_lmdb: Optional[str] = None
     dict_path: Optional[str] = None
     remove_hydrogen: bool = False
@@ -17,6 +20,8 @@ class DatasetConfig:
     mask_prob: float = 0.15
     leave_unmasked_prob: float = 0.1
     random_token_prob: float = 0.1
+    unimol_style: bool = False
+    num_conformers: int = 10
 
 @dataclass
 class ModelConfig:
@@ -59,8 +64,16 @@ class PretrainConfig:
     training: TrainingConfig = field(default_factory=TrainingConfig)
 
     def validate(self):
-        if self.dataset.train_lmdb is MISSING:
-            raise ValueError("train_lmdb must be specified in the dataset configuration.")
+        if self.dataset.data_type == "lmdb":
+            if not self.dataset.train_lmdb:
+                raise ValueError(
+                    "train_lmdb must be specified when data_type is 'lmdb'."
+                )
+        else:
+            if not self.dataset.train_path:
+                raise ValueError(
+                    "train_path must be specified when data_type is not 'lmdb'."
+                )
         if self.model.encoder_layers <= 0:
             raise ValueError("encoder_layers must be a positive integer.")
         if self.training.batch_size <= 0:

--- a/unimol_tools/pretrain/trainer.py
+++ b/unimol_tools/pretrain/trainer.py
@@ -16,9 +16,10 @@ from torch.utils.tensorboard import SummaryWriter
 logger = logging.getLogger(__name__)
 
 class UniMolPretrainTrainer:
-    def __init__(self, model, dataset, loss_fn, config, local_rank=0, resume: str=None):
+    def __init__(self, model, dataset, loss_fn, config, local_rank=0, resume: str=None, valid_dataset=None):
         self.model = model
         self.dataset = dataset
+        self.valid_dataset = valid_dataset
         self.loss_fn = loss_fn
         self.config = config
         self.local_rank = local_rank
@@ -40,18 +41,26 @@ class UniMolPretrainTrainer:
             self.model = self.model.cuda()
 
         self.optimizer = optim.Adam(
-            self.model.parameters(), 
+            self.model.parameters(),
             lr=self.config.lr,
             weight_decay=self.config.weight_decay,
             )
         self.criterion = nn.CrossEntropyLoss()
 
+        self.best_loss = float("inf")
+
 
         # DDP DataLoader
         if 'WORLD_SIZE' in os.environ and int(os.environ['WORLD_SIZE']) > 1:
             self.sampler = torch.utils.data.distributed.DistributedSampler(self.dataset)
+            self.valid_sampler = (
+                torch.utils.data.distributed.DistributedSampler(self.valid_dataset, shuffle=False)
+                if self.valid_dataset is not None
+                else None
+            )
         else:
             self.sampler = None
+            self.valid_sampler = None
         logger.info(f"Using sampler: {self.sampler}")
 
         g = torch.Generator()
@@ -68,22 +77,40 @@ class UniMolPretrainTrainer:
             worker_init_fn=seed_worker,
             generator=g,
         )
+        if self.valid_dataset is not None:
+            self.valid_dataloader = DataLoader(
+                self.valid_dataset,
+                batch_size=self.config.batch_size,
+                shuffle=False,
+                sampler=self.valid_sampler,
+                num_workers=4,
+                pin_memory=True,
+                collate_fn=self.model.batch_collate_fn,
+            )
+        else:
+            self.valid_dataloader = None
 
-        # resume training from a checkpoint if provided
+        # resume training from a checkpoint if provided or detect last
         self.start_epoch = 0
         self.global_step = 0
-        if resume is not None and os.path.isfile(resume):
-            self._load_checkpoint(resume)
+        resume_path = resume
+        if resume_path is None:
+            last_ckpt = self.ckpt_dir / 'checkpoint_last.ckpt'
+            if last_ckpt.exists():
+                resume_path = str(last_ckpt)
+        if resume_path is not None and os.path.isfile(resume_path):
+            self._load_checkpoint(resume_path)
 
     def train(self, epochs=None):
         epochs = epochs or self.config.epochs
         save_every = getattr(self.config, "save_every_n_epoch", 5)
 
-        logging_infos = []
         for epoch in range(self.start_epoch, epochs):
             if self.sampler:
                 self.sampler.set_epoch(epoch)
             self.model.train()
+            logger.info(f"Starting epoch {epoch}")
+            logging_infos = []
 
             for i, batch in enumerate(self.dataloader):
                 net_input, net_target = self.decorate_batch(batch)
@@ -92,19 +119,40 @@ class UniMolPretrainTrainer:
                 loss.backward()
                 self.optimizer.step()
                 logging_infos.append(logging_info)
+                self.global_step += 1
 
                 if self.writer:
-                    self.writer.add_scalar('Step/loss', loss.item(), epoch * len(self.dataloader) + i)
+                    step_idx = epoch * len(self.dataloader) + i
+                    self.writer.add_scalar('Step/loss', loss.item(), step_idx)
                     for key, value in logging_info.items():
                         if key == 'loss':
                             continue
-                        self.writer.add_scalar(f'Step/{key}', value, epoch * len(self.dataloader) + i)
-            if self.local_rank == 0:
-                self.reduce_metrics(logging_infos, writer=self.writer, logger=logger, epoch=epoch, split="train")
+                        self.writer.add_scalar(f'Step/{key}', value, step_idx)
 
-            self._save_checkpoint(epoch)
-            if (epoch + 1) % save_every == 0:
-                self._save_checkpoint(epoch, epoch)
+            metrics = None
+            if self.local_rank == 0:
+                metrics = self.reduce_metrics(logging_infos, writer=self.writer, logger=logger, epoch=epoch, split="train")
+
+            should_save = (epoch + 1) % save_every == 0
+            val_metrics = None
+            if should_save and self.valid_dataloader is not None:
+                val_metrics = self.evaluate(epoch)
+
+            if self.local_rank == 0 and should_save:
+                curr_loss = None
+                if val_metrics is not None:
+                    curr_loss = val_metrics.get('loss', float('inf'))
+                elif metrics is not None:
+                    curr_loss = metrics.get('loss', float('inf'))
+                if curr_loss is not None:
+                    self._save_checkpoint(epoch, 'checkpoint_last.ckpt')
+                    if curr_loss < self.best_loss:
+                        self.best_loss = curr_loss
+                        logger.info(f"New best model at epoch {epoch} with loss {curr_loss:.4f}")
+                        self._save_checkpoint(epoch, 'checkpoint_best.ckpt')
+                    self._save_checkpoint(epoch, epoch)
+            elif self.local_rank == 0 and not should_save:
+                logger.info(f"Skipping validation and checkpointing at epoch {epoch}")
 
         if self.writer:
             self.writer.close()
@@ -126,10 +174,9 @@ class UniMolPretrainTrainer:
             save_name = f'epoch_{name}.ckpt'
         else:
             save_name = name
-            if not save_name.endswith('.ckpt'):
-                save_name += '.ckpt'
         save_path = os.path.join(self.ckpt_dir, save_name)
         torch.save(ckpt, save_path)
+        logger.info(f"Saved checkpoint: {save_path}")
         if isinstance(name, int):
             self._cleanup_old_checkpoints(keep=3)
 
@@ -150,6 +197,18 @@ class UniMolPretrainTrainer:
         epoch_files = sorted(self.ckpt_dir.glob("epoch_*.ckpt"), key=lambda p: int(p.stem.split("_")[1]))
         for f in epoch_files[:-keep]:
             f.unlink()
+
+    def evaluate(self, epoch):
+        self.model.eval()
+        logging_infos = []
+        with torch.no_grad():
+            for batch in self.valid_dataloader:
+                net_input, net_target = self.decorate_batch(batch)
+                loss, logging_info = self.loss_fn(self.model, net_input, net_target)
+                logging_infos.append(logging_info)
+        metrics = self.reduce_metrics(logging_infos, writer=self.writer, logger=logger, epoch=epoch, split="valid")
+        self.model.train()
+        return metrics
 
     def decorate_batch(self, batch):
         # batch is a dict of tensors (batch_size, ...)
@@ -203,3 +262,4 @@ def seed_worker(worker_id):
     worker_seed = torch.initial_seed() % 2**32
     random.seed(worker_seed)
     np.random.seed(worker_seed)
+

--- a/unimol_tools/run_pretrain.py
+++ b/unimol_tools/run_pretrain.py
@@ -1,14 +1,23 @@
 import os
 import random
+import logging
 
 import hydra
 import numpy as np
 import torch
 from omegaconf import DictConfig, OmegaConf
 
-from unimol_tools.pretrain import (LMDBDataset, UniMolDataset, UniMolloss,
-                                   UniMolModel, UniMolPretrainTrainer,
-                                   build_dictionary)
+from unimol_tools.pretrain import (
+    LMDBDataset,
+    UniMolDataset,
+    UniMolloss,
+    UniMolModel,
+    UniMolPretrainTrainer,
+    build_dictionary,
+    preprocess_dataset,
+)
+
+logger = logging.getLogger(__name__)
 
 
 class MolPretrain:
@@ -18,28 +27,90 @@ class MolPretrain:
         self.local_rank = getattr(self.config.training, 'local_rank', 0)
         seed = getattr(self.config.training, 'seed', 42)
         self.set_seed(seed)
+
+        # Preprocess dataset if necessary
+        ds_cfg = self.config.dataset
+        if ds_cfg.data_type != 'lmdb':
+            lmdb_path = ds_cfg.train_lmdb or os.path.splitext(ds_cfg.train_path)[0] + '.lmdb'
+            logger.info(
+                f"Preprocessing training data from {ds_cfg.train_path} to {lmdb_path}"
+            )
+            preprocess_dataset(
+                ds_cfg.train_path,
+                lmdb_path,
+                data_type=ds_cfg.data_type,
+                smiles_col=ds_cfg.smiles_column,
+                num_conf=ds_cfg.num_conformers if ds_cfg.unimol_style else 1,
+                unimol_style=ds_cfg.unimol_style,
+                remove_hs=ds_cfg.remove_hydrogen,
+            )
+            ds_cfg.train_lmdb = lmdb_path
+            logger.info(f"Dataset preprocessing finished, LMDB saved at {lmdb_path}")
+
+            if ds_cfg.valid_path:
+                val_lmdb = ds_cfg.valid_lmdb or os.path.splitext(ds_cfg.valid_path)[0] + '.lmdb'
+                logger.info(
+                    f"Preprocessing validation data from {ds_cfg.valid_path} to {val_lmdb}"
+                )
+                preprocess_dataset(
+                    ds_cfg.valid_path,
+                    val_lmdb,
+                    data_type=ds_cfg.data_type,
+                    smiles_col=ds_cfg.smiles_column,
+                    num_conf=ds_cfg.num_conformers if ds_cfg.unimol_style else 1,
+                    unimol_style=ds_cfg.unimol_style,
+                    remove_hs=ds_cfg.remove_hydrogen,
+                )
+                ds_cfg.valid_lmdb = val_lmdb
+                logger.info(
+                    f"Validation dataset preprocessing finished, LMDB saved at {val_lmdb}"
+                )
+
         # Build dictionary
-        dict_path = self.config.dataset.get('dict_path', None)
+        dict_path = ds_cfg.get('dict_path', None)
         if dict_path:
             from unimol_tools.data.dictionary import Dictionary
             self.dictionary = Dictionary.load(dict_path)
+            logger.info(f"Loaded dictionary from {dict_path}")
         else:
-            self.dictionary = build_dictionary(self.config.dataset.train_lmdb)
+            self.dictionary = build_dictionary(ds_cfg.train_lmdb)
+            logger.info("Built dictionary from training LMDB")
 
         # Build dataset
-        lmdb_dataset = LMDBDataset(self.config.dataset.train_lmdb)
+        logger.info(f"Loading LMDB dataset from {ds_cfg.train_lmdb}")
+        lmdb_dataset = LMDBDataset(ds_cfg.train_lmdb)
         self.dataset = UniMolDataset(
             lmdb_dataset,
             self.dictionary,
-            remove_hs=self.config.dataset.remove_hydrogen,
-            max_atoms=self.config.dataset.max_atoms,
+            remove_hs=ds_cfg.remove_hydrogen,
+            max_atoms=ds_cfg.max_atoms,
             seed=seed,
-            noise_type=self.config.dataset.noise_type,
-            noise=self.config.dataset.noise,
-            mask_prob=self.config.dataset.mask_prob,
-            leave_unmasked_prob=self.config.dataset.leave_unmasked_prob,
-            random_token_prob=self.config.dataset.random_token_prob,
+            noise_type=ds_cfg.noise_type,
+            noise=ds_cfg.noise,
+            mask_prob=ds_cfg.mask_prob,
+            leave_unmasked_prob=ds_cfg.leave_unmasked_prob,
+            random_token_prob=ds_cfg.random_token_prob,
+            sample_conformer=ds_cfg.unimol_style,
         )
+
+        if ds_cfg.valid_lmdb:
+            logger.info(f"Loading validation LMDB dataset from {ds_cfg.valid_lmdb}")
+            val_lmdb_dataset = LMDBDataset(ds_cfg.valid_lmdb)
+            self.valid_dataset = UniMolDataset(
+                val_lmdb_dataset,
+                self.dictionary,
+                remove_hs=ds_cfg.remove_hydrogen,
+                max_atoms=ds_cfg.max_atoms,
+                seed=seed,
+                noise_type=ds_cfg.noise_type,
+                noise=ds_cfg.noise,
+                mask_prob=ds_cfg.mask_prob,
+                leave_unmasked_prob=ds_cfg.leave_unmasked_prob,
+                random_token_prob=ds_cfg.random_token_prob,
+                sample_conformer=ds_cfg.unimol_style,
+            )
+        else:
+            self.valid_dataset = None
 
     def pretrain(self):
         # Build model
@@ -60,11 +131,12 @@ class MolPretrain:
             loss_fn,
             self.config.training,
             local_rank=self.local_rank,
-            resume=self.config.training.get('resume', None)
+            resume=self.config.training.get('resume', None),
+            valid_dataset=self.valid_dataset,
         )
+        logger.info("Starting pretraining")
         trainer.train(epochs=self.config.training.epochs)
-        # Save model
-        trainer.save('unimol_pretrain.pth')
+        logger.info("Training finished. Checkpoints saved under the run directory.")
 
     def set_seed(self, seed):
             random.seed(seed)


### PR DESCRIPTION
## Summary
- allow pretrain dataset generation with multiple conformers
- random conformer sampling support in `UniMolDataset`
- automatically resume from `checkpoint_last.ckpt` and update `checkpoint_best.ckpt` using validation loss
- run_pretrain preprocesses CSV/SMI inputs with `smi` column and handles validation sets
- save last/best pretrain checkpoints and support dict-based datasets
- add richer logging in preprocessing, trainer, and runner
- support SDF files in preprocessing with new test coverage
- run validation and checkpoint saving only every `save_every_n_epoch` epochs

## Testing
- `pip install numba -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688c51791420832fb00be732c3101727